### PR TITLE
use PORTAGE_LOGDIR as log storage, improve Bash stability, type hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,20 +11,23 @@ from 2023 Google Summer of Code.
 
 #### Usage
 `gentoo-update` is in [GURU](https://wiki.gentoo.org/wiki/Project:GURU) 
-overlay, and can be installed using emerge:
-```bash
-emerge --ask app-admin/gentoo_update
-```
-Because the project is in early stage of development it's not considered stable 
-and is masked by `~amd64`. To unmask it run:
+overlay, and can be installed using `emerge`. But because the project is 
+in early stage of development it's not considered stable and is masked by 
+`~amd64`. To unmask and install it, run:
 ```bash
 echo 'app-admin/gentoo_update ~amd64' >> /etc/portage/package.accept_keywords/gentoo_update
+emerge --ask app-admin/gentoo_update
 ```
 
 Alternatively, updater can be installed with pip:
 ```
 pip install gentoo_update --break-system-packages
 ```
+
+The updater will not display build logs by default, so it's recommended to 
+define `PORTAGE_LOGDIR` in `/etc/portage/make.conf`. If this option is defined, 
+updater will use it to store it's own logs as well.  
+
 
 Here are some usage examples:
 * Basic security update

--- a/gentoo_update/gentoo_update.py
+++ b/gentoo_update/gentoo_update.py
@@ -1,6 +1,7 @@
 import os
 import argparse
 from .shell_runner import ShellRunner
+from typing import List
 
 __version__ = "0.1.5"
 current_path = os.path.dirname(os.path.realpath(__file__))
@@ -97,7 +98,7 @@ def create_cli() -> argparse.Namespace:
     return args
 
 
-def add_prefixes(args_list: list[str]) -> list[str]:
+def add_prefixes(args_list: List[str]) -> List[str]:
     """
     Function to add prefixes to a list of arguments passed to
     --update-mode full.

--- a/gentoo_update/gentoo_update.py
+++ b/gentoo_update/gentoo_update.py
@@ -6,7 +6,7 @@ __version__ = "0.1.5"
 current_path = os.path.dirname(os.path.realpath(__file__))
 
 
-def create_cli():
+def create_cli() -> argparse.Namespace:
     """
     Define CLI command flags using argparse.
 
@@ -94,10 +94,11 @@ def create_cli():
     )
 
     args = parser.parse_args()
+    print(type(args))
     return args
 
 
-def add_prefixes(args_list):
+def add_prefixes(args_list: list[str]) -> list[str]:
     """
     Function to add prefixes to a list of arguments passed to
     --update-mode full.
@@ -121,7 +122,7 @@ def add_prefixes(args_list):
     return prefixed_args
 
 
-def main():
+def main() -> None:
     args = create_cli()
     runner = ShellRunner(args.quiet)
 

--- a/gentoo_update/gentoo_update.py
+++ b/gentoo_update/gentoo_update.py
@@ -94,7 +94,6 @@ def create_cli() -> argparse.Namespace:
     )
 
     args = parser.parse_args()
-    print(type(args))
     return args
 
 

--- a/gentoo_update/gentoo_update.py
+++ b/gentoo_update/gentoo_update.py
@@ -2,7 +2,7 @@ import os
 import argparse
 from .shell_runner import ShellRunner
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"
 current_path = os.path.dirname(os.path.realpath(__file__))
 
 

--- a/gentoo_update/scripts/updater.sh
+++ b/gentoo_update/scripts/updater.sh
@@ -95,11 +95,16 @@ function clean_up() {
 		echo "Cleaning packages that are not part of the tree..."
 		emerge --depclean
 
-		echo "Checking reverse dependencies..."
-		revdep-rebuild
+		if command -v revdep-rebuild >/dev/null 2>&1; then
+			echo "Checking reverse dependencies..."
+			revdep-rebuild
 
-		echo "Clean source code..."
-		eclean --deep distfiles
+			echo "Clean source code..."
+			eclean --deep distfiles
+		else
+			echo "app-portage/gentoolkit is not installed"
+		fi
+
 	else
 		echo "Clean up is not enabled."
 	fi

--- a/gentoo_update/scripts/updater.sh
+++ b/gentoo_update/scripts/updater.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
 # ---------------------- VARIABLES ----------------------- #
 UPDATE_MODE="${1}"

--- a/gentoo_update/scripts/updater.sh
+++ b/gentoo_update/scripts/updater.sh
@@ -108,13 +108,18 @@ function clean_up() {
 # -------------------- CHECK_RESTART --------------------- #
 function check_restart() {
 	restart="${DAEMON_RESTART}"
-	echo "Checking is any service needs a restart"
-	if [[ "${restart}" == 'y' ]]; then
-		# automatically restart all services
-		needrestart -r a
+
+	if command -v needrestart >/dev/null 2>&1; then
+		echo "Checking is any service needs a restart"
+		if [[ "${restart}" == 'y' ]]; then
+			# automatically restart all services
+			needrestart -r a
+		else
+			# list services that require a restart
+			needrestart -r l
+		fi
 	else
-		# list services that require a restart
-		needrestart -r l
+		echo "app-admin/needrestart is not installed"
 	fi
 }
 

--- a/gentoo_update/shell_runner.py
+++ b/gentoo_update/shell_runner.py
@@ -5,6 +5,7 @@ import logging
 import subprocess
 from configparser import ConfigParser
 from datetime import datetime
+from typing import Tuple, List
 
 
 class ShellRunner:
@@ -32,7 +33,7 @@ class ShellRunner:
             config.read_string("[DEFAULT]\n" + config_string.read())
         return config
 
-    def initiate_log_directory(self) -> tuple(str, list[str]):
+    def initiate_log_directory(self) -> Tuple[str, List[str]]:
         """
         Create log directory if it does not exist.
         If PORTAGE_LOGDIR is not set, use the default directory.
@@ -102,7 +103,7 @@ class ShellRunner:
 
     def _log_stream_output(
         self, stream_obj: subprocess.Popen, type: str
-    ) -> list:
+    ) -> List[str]:
         """
         Process sterr from the upadte script.
 

--- a/gentoo_update/shell_runner.py
+++ b/gentoo_update/shell_runner.py
@@ -41,7 +41,11 @@ class ShellRunner:
             str: Log directory path.
             List[str]: List of messages to be logged.
         """
-        log_dir = self.make_conf["DEFAULT"]["PORTAGE_LOGDIR"].replace('"', "")
+        try:
+            log_dir = self.make_conf["DEFAULT"]["PORTAGE_LOGDIR"]
+        except KeyError:
+            log_dir = ""
+
         log_dir_messages = []
         if log_dir == "":
             log_dir = "/var/log/portage/gentoo-update"
@@ -49,6 +53,7 @@ class ShellRunner:
                 f"PORTAGE_LOGDIR not set, using default: {log_dir}"
             )
         else:
+            log_dir = log_dir.replace('"', "")
             log_dir = f"{log_dir}/gentoo-update"
             log_dir_messages.append(f"PORTAGE_LOGDIR set, using: {log_dir}")
 

--- a/gentoo_update/shell_runner.py
+++ b/gentoo_update/shell_runner.py
@@ -32,7 +32,7 @@ class ShellRunner:
             config.read_string("[DEFAULT]\n" + config_string.read())
         return config
 
-    def initiate_log_directory(self):
+    def initiate_log_directory(self) -> tuple(str, list[str]):
         """
         Create log directory if it does not exist.
         If PORTAGE_LOGDIR is not set, use the default directory.

--- a/gentoo_update/shell_runner.py
+++ b/gentoo_update/shell_runner.py
@@ -7,7 +7,7 @@ from datetime import datetime
 
 
 class ShellRunner:
-    def __init__(self, quiet):
+    def __init__(self, quiet: str) -> None:
         self.quiet = True if quiet == "y" else False
 
         self.timestamp = datetime.now().strftime("%Y-%m-%d-%H-%M")
@@ -18,7 +18,7 @@ class ShellRunner:
         self.script_dir = os.path.join(os.path.dirname(__file__), "scripts")
         self.script_path = os.path.join(self.script_dir, "updater.sh")
 
-    def initiate_logger(self):
+    def initiate_logger(self) -> logging.Logger:
         """
         Create a logger with two handlers:
             1. terminal output
@@ -55,7 +55,9 @@ class ShellRunner:
 
         return logger
 
-    def _log_stream_output(self, stream_obj, type):
+    def _log_stream_output(
+        self, stream_obj: subprocess.Popen, type: str
+    ) -> list:
         """
         Process sterr from the upadte script.
 
@@ -82,7 +84,7 @@ class ShellRunner:
                 self.logger.error(line)
         return output
 
-    def _exit_with_error_message(self, stream):
+    def _exit_with_error_message(self, stream: subprocess.Popen) -> None:
         """
         Exit runner if updater.sh encounters an error and
         print/log that error.
@@ -102,7 +104,7 @@ class ShellRunner:
         self.logger.error(error_message)
         sys.exit(stream.returncode)
 
-    def run_shell_script(self, *args):
+    def run_shell_script(self, *args: str) -> None:
         """
         Run a shell script and stream standard output
         and standard error to terminal and a log file.
@@ -132,7 +134,7 @@ class ShellRunner:
         if self.quiet:
             print(final_message)
 
-    def __del__(self):
+    def __del__(self) -> None:
         """
         Closed all file handlers after ShellRunner is closed.
         """

--- a/tests/compose.yaml
+++ b/tests/compose.yaml
@@ -8,6 +8,14 @@ services:
       - ./logs:/var/log/gentoo_update
       - ./run_tests.sh:/tmp/run_tests.sh
 
+  gentoo2_source:
+    build: https://raw.githubusercontent.com/Lab-Brat/gentoo_dockerfiles/main/stage3_systemd.Dockerfile
+    command: ["/bin/sh", "-c", "/tmp/run_tests.sh pip_install && /tmp/run_tests.sh full_update_all_options"]
+    volumes:
+      - ../../gentoo_update/:/root/gentoo_update_source
+      - ./logs:/var/log/gentoo_update
+      - ./run_tests.sh:/tmp/run_tests.sh
+
   gentoo1:
     build: https://raw.githubusercontent.com/Lab-Brat/gentoo_dockerfiles/main/stage3_openrc.Dockerfile
     command: ["/bin/sh", "-c", "/tmp/run_tests.sh emerge_install && /tmp/run_tests.sh sec_update"]

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,25 +1,26 @@
 #!/bin/bash
 
+set -euo pipefail
+
 emerge_install() {
-    # Install from GURU repository
-    echo "app-admin/gentoo_update ~amd64" >> /etc/portage/package.accept_keywords/gentoo_update
-    emerge --quiet-build y app-admin/gentoo_update
+	# Install from GURU repository
+	echo "app-admin/gentoo_update ~amd64" >>/etc/portage/package.accept_keywords/gentoo_update
+	emerge --quiet-build y app-admin/gentoo_update
 }
 
 pip_install() {
-    # Install with pip
-    cd /root/gentoo_update_source && pip install . --break-system-packages
+	# Install with pip
+	cd /root/gentoo_update_source && pip install . --break-system-packages
 }
 
 sec_update() {
-    # Run the gentoo-update in secure mode
-    gentoo-update
+	# Run the gentoo-update in secure mode
+	gentoo-update
 }
 
 full_update() {
-    # Run the gentoo-update in full update mode
-    gentoo-update -m full
+	# Run the gentoo-update in full update mode
+	gentoo-update -m full
 }
 
 "$@"
-

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -20,7 +20,17 @@ sec_update() {
 
 full_update() {
 	# Run the gentoo-update in full update mode
-	gentoo-update -m full
+	gentoo-update --update-mode full
+}
+
+full_update_all_options() {
+	# Run the gentoo-update in full update mode and all options enabled
+	gentoo-update --update-mode full \
+		--config-update-mode merge \
+		--daemon-restart y \
+		--clean y \
+		--read-logs y \
+		--read-news y
 }
 
 "$@"


### PR DESCRIPTION
Changelog:
* Read `PORTAGE_LOGDIR` variable from `make.conf` and use it to store logs
* Before running `needrestart`, `eclean` or `revdep-rebuild` actually check if it's installed first
* Install dependencies with USE flags.
* Add type hints to Python functions and methods
* Change `set -e` to `set -euo pipefail`
* Update README.md