### PR TITLE
Fix Python wheel build warnings, rework --args flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ gentoo-update
 
 * Full system update with extra update parameters
 ```bash
-gentoo-update --update-mode full --args color=n
+gentoo-update --update-mode full --args "color=y keep-going"
 ```
 
 * Full system update, show elogs and news

--- a/gentoo_update/gentoo_update.py
+++ b/gentoo_update/gentoo_update.py
@@ -34,7 +34,9 @@ def create_cli() -> argparse.Namespace:
         "-a",
         "--args",
         default="",
-        help="Additional arguments to be passed when in 'full' update mode.",
+        help="Additional arguments to be passed when in 'full' update mode.\n"
+        "Example:\n"
+        "--args 'quiet-build=n color=y keep-going'",
     )
     parser.add_argument(
         "-c",
@@ -103,12 +105,12 @@ def add_prefixes(args: str) -> str:
     --update-mode full.
 
     Parameters:
-    args_list (List[str]): A list of arguments without prefixes,
-        example: v quiet-build=y
+    args_list (str): A string of space separated arguments without prefixes 
+        example: "quiet-build=n color=y keep-going"
 
     Returns:
-    List[str]: A new list of arguments with added prefixes,
-        example: -v --quiet-build=y
+    str: A new string of space separated arguments with added prefixes,
+        example: "--quiet-build=n --color=y --keep-going"
     """
     args = args.split(" ")
     print(args)

--- a/gentoo_update/gentoo_update.py
+++ b/gentoo_update/gentoo_update.py
@@ -3,7 +3,7 @@ import argparse
 from .shell_runner import ShellRunner
 from typing import List
 
-__version__ = "0.1.5"
+__version__ = "0.1.6"
 current_path = os.path.dirname(os.path.realpath(__file__))
 
 

--- a/gentoo_update/gentoo_update.py
+++ b/gentoo_update/gentoo_update.py
@@ -1,7 +1,6 @@
 import os
 import argparse
 from .shell_runner import ShellRunner
-from typing import List
 
 __version__ = "0.1.6"
 current_path = os.path.dirname(os.path.realpath(__file__))
@@ -34,7 +33,7 @@ def create_cli() -> argparse.Namespace:
     parser.add_argument(
         "-a",
         "--args",
-        nargs="*",
+        default="",
         help="Additional arguments to be passed when in 'full' update mode.",
     )
     parser.add_argument(
@@ -98,7 +97,7 @@ def create_cli() -> argparse.Namespace:
     return args
 
 
-def add_prefixes(args_list: List[str]) -> List[str]:
+def add_prefixes(args: str) -> str:
     """
     Function to add prefixes to a list of arguments passed to
     --update-mode full.
@@ -111,15 +110,17 @@ def add_prefixes(args_list: List[str]) -> List[str]:
     List[str]: A new list of arguments with added prefixes,
         example: -v --quiet-build=y
     """
+    args = args.split(" ")
+    print(args)
     prefixed_args = []
 
-    for arg in args_list:
+    for arg in args:
         if len(arg) == 1:
             prefixed_args.append("-" + arg)
         else:
             prefixed_args.append("--" + arg)
-
-    return prefixed_args
+    print(prefixed_args)
+    return " ".join(prefixed_args)
 
 
 def main() -> None:
@@ -128,7 +129,7 @@ def main() -> None:
 
     runner.run_shell_script(
         args.update_mode,
-        " ".join(add_prefixes(args.args)) if args.args else "NOARGS",
+        add_prefixes(args.args) if args.args else "NOARGS",
         args.config_update_mode,
         args.daemon_restart,
         args.clean,

--- a/gentoo_update/scripts/updater.sh
+++ b/gentoo_update/scripts/updater.sh
@@ -37,19 +37,20 @@ function update_security() {
 
 function emerge_full() {
     # run emerge with custom flags
-    local update_flags=("$@")
-    emerge --verbose --quiet-build y \
-        --update --newuse --deep "${update_flags[@]}" @world
+    local update_flags="${1}"
+    echo "Update command:"
+    echo "emerge --verbose --quiet-build=y --update --newuse --deep ${update_flags} @world"
+    eval "emerge --verbose --quiet-build=y --update --newuse --deep ${update_flags} @world"
 }
 
 function update_full() {
-    read -r -a update_flags <<<"${UPDATE_FLAGS}"
+    update_flags="${UPDATE_FLAGS}"
 
     # Do a full system update
     echo "Running Update: Check Pretend First"
     if emerge --pretend --update --newuse --deep @world; then
         echo "emerge pretend was successful, updating..."
-        emerge_full "${update_flags[@]}"
+        emerge_full "${update_flags}"
     else
         echo "emerge pretend has failed, not updating"
     fi

--- a/gentoo_update/scripts/updater.sh
+++ b/gentoo_update/scripts/updater.sh
@@ -35,15 +35,21 @@ function update_security() {
 	fi
 }
 
-function update_full() {
-	# Do a full system update
-	IFS=' ' read -r -a update_flags <<<"${UPDATE_FLAGS}"
+function emerge_full() {
+	# run emerge with custom flags
+	local update_flags=("$@")
+	emerge --verbose --quiet-build y \
+		--update --newuse --deep "${update_flags[@]}" @world
+}
 
+function update_full() {
+	read -r -a update_flags <<<"${UPDATE_FLAGS}"
+
+	# Do a full system update
 	echo "Running Update: Check Pretend First"
 	if emerge --pretend --update --newuse --deep @world; then
 		echo "emerge pretend was successful, updating..."
-		emerge --verbose --quiet-build y \
-			--update --newuse --deep "${update_flags[@]}" @world
+		emerge_full "${update_flags[@]}"
 	else
 		echo "emerge pretend has failed, not updating"
 	fi

--- a/gentoo_update/scripts/updater.sh
+++ b/gentoo_update/scripts/updater.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 UPDATE_MODE="${1}"
 UPDATE_FLAGS="${2}"
 if [[ "${UPDATE_FLAGS}" == "NOARGS" ]]; then
-	UPDATE_FLAGS=""
+    UPDATE_FLAGS=""
 fi
 CONFIG_UPDATE_MODE="${3}"
 DAEMON_RESTART="${4}"
@@ -16,171 +16,171 @@ READ_NEWS="${7}"
 
 # ------------------ SYNC_PORTAGE_TREE ------------------- #
 function sync_tree() {
-	# Update main Portage tree
-	echo "Syncing Portage Tree"
-	emerge --sync
+    # Update main Portage tree
+    echo "Syncing Portage Tree"
+    emerge --sync
 }
 
 # -------------------- UPDATE_SYSTEM --------------------- #
 function update_security() {
-	# Check for GLSAs and install updates if necessary
-	glsa=$(glsa-check --list affected)
+    # Check for GLSAs and install updates if necessary
+    glsa=$(glsa-check --list affected)
 
-	if [ -z "${glsa}" ]; then
-		echo "No affected GLSAs found."
-	else
-		echo "Affected GLSAs found. Applying updates..."
-		glsa-check --fix affected
-		echo "Updates applied."
-	fi
+    if [ -z "${glsa}" ]; then
+        echo "No affected GLSAs found."
+    else
+        echo "Affected GLSAs found. Applying updates..."
+        glsa-check --fix affected
+        echo "Updates applied."
+    fi
 }
 
 function emerge_full() {
-	# run emerge with custom flags
-	local update_flags=("$@")
-	emerge --verbose --quiet-build y \
-		--update --newuse --deep "${update_flags[@]}" @world
+    # run emerge with custom flags
+    local update_flags=("$@")
+    emerge --verbose --quiet-build y \
+        --update --newuse --deep "${update_flags[@]}" @world
 }
 
 function update_full() {
-	read -r -a update_flags <<<"${UPDATE_FLAGS}"
+    read -r -a update_flags <<<"${UPDATE_FLAGS}"
 
-	# Do a full system update
-	echo "Running Update: Check Pretend First"
-	if emerge --pretend --update --newuse --deep @world; then
-		echo "emerge pretend was successful, updating..."
-		emerge_full "${update_flags[@]}"
-	else
-		echo "emerge pretend has failed, not updating"
-	fi
+    # Do a full system update
+    echo "Running Update: Check Pretend First"
+    if emerge --pretend --update --newuse --deep @world; then
+        echo "emerge pretend was successful, updating..."
+        emerge_full "${update_flags[@]}"
+    else
+        echo "emerge pretend has failed, not updating"
+    fi
 }
 
 function update() {
-	update_mode="${UPDATE_MODE}"
-	# Do security updates or full system updates
-	if [[ "${update_mode}" == 'security' ]]; then
-		echo -e "installing security updates only\n"
-		update_security
-		echo ""
+    update_mode="${UPDATE_MODE}"
+    # Do security updates or full system updates
+    if [[ "${update_mode}" == 'security' ]]; then
+        echo -e "installing security updates only\n"
+        update_security
+        echo ""
 
-	elif [[ "${update_mode}" == 'full' ]]; then
-		echo -e "updating @world\n"
-		update_full
-		echo ""
+    elif [[ "${update_mode}" == 'full' ]]; then
+        echo -e "updating @world\n"
+        update_full
+        echo ""
 
-	else
-		echo "Invalid update mode, exiting...."
-		exit 1
-	fi
+    else
+        echo "Invalid update mode, exiting...."
+        exit 1
+    fi
 }
 
 # ---------------- UPDATE_CONFIGURATIONS ----------------- #
 function config_update() {
-	update_mode="${CONFIG_UPDATE_MODE}"
+    update_mode="${CONFIG_UPDATE_MODE}"
 
-	# Perform the update based on the update mode
-	if [[ "${update_mode}" == "merge" ]]; then
-		etc-update --automode -5
-	elif [[ "${update_mode}" == "interactive" ]]; then
-		etc-update
-	elif [[ "${update_mode}" == "dispatch" ]]; then
-		dispatch-conf
-	elif [[ "${update_mode}" == "ignore" ]]; then
-		echo "Ignoring configuration update for now..."
-		echo "Please UPDATE IT MANUALLY LATER"
-	else
-		echo "Invalid update mode: ${update_mode}" >&2
-		echo "Please set UPDATE_MODE to 'merge', 'interactive', 'dispatch' or 'ignore'." >&2
-	fi
+    # Perform the update based on the update mode
+    if [[ "${update_mode}" == "merge" ]]; then
+        etc-update --automode -5
+    elif [[ "${update_mode}" == "interactive" ]]; then
+        etc-update
+    elif [[ "${update_mode}" == "dispatch" ]]; then
+        dispatch-conf
+    elif [[ "${update_mode}" == "ignore" ]]; then
+        echo "Ignoring configuration update for now..."
+        echo "Please UPDATE IT MANUALLY LATER"
+    else
+        echo "Invalid update mode: ${update_mode}" >&2
+        echo "Please set UPDATE_MODE to 'merge', 'interactive', 'dispatch' or 'ignore'." >&2
+    fi
 }
 
 # ----------------------- CLEAN_UP ----------------------- #
 function clean_up() {
-	clean="${CLEAN}"
-	if [[ "${clean}" == 'y' ]]; then
-		echo "Cleaning packages that are not part of the tree..."
-		emerge --depclean
+    clean="${CLEAN}"
+    if [[ "${clean}" == 'y' ]]; then
+        echo "Cleaning packages that are not part of the tree..."
+        emerge --depclean
 
-		if command -v revdep-rebuild >/dev/null 2>&1; then
-			echo "Checking reverse dependencies..."
-			revdep-rebuild
+        if command -v revdep-rebuild >/dev/null 2>&1; then
+            echo "Checking reverse dependencies..."
+            revdep-rebuild
 
-			echo "Clean source code..."
-			eclean --deep distfiles
-		else
-			echo "app-portage/gentoolkit is not installed"
-		fi
+            echo "Clean source code..."
+            eclean --deep distfiles
+        else
+            echo "app-portage/gentoolkit is not installed"
+        fi
 
-	else
-		echo "Clean up is not enabled."
-	fi
+    else
+        echo "Clean up is not enabled."
+    fi
 }
 
 # -------------------- CHECK_RESTART --------------------- #
 function check_restart() {
-	restart="${DAEMON_RESTART}"
+    restart="${DAEMON_RESTART}"
 
-	if command -v needrestart >/dev/null 2>&1; then
-		echo "Checking is any service needs a restart"
-		if [[ "${restart}" == 'y' ]]; then
-			# automatically restart all services
-			needrestart -r a
-		else
-			# list services that require a restart
-			needrestart -r l
-		fi
-	else
-		echo "app-admin/needrestart is not installed"
-	fi
+    if command -v needrestart >/dev/null 2>&1; then
+        echo "Checking is any service needs a restart"
+        if [[ "${restart}" == 'y' ]]; then
+            # automatically restart all services
+            needrestart -r a
+        else
+            # list services that require a restart
+            needrestart -r l
+        fi
+    else
+        echo "app-admin/needrestart is not installed"
+    fi
 }
 
 # ---------------------- GET_ELOGS ----------------------- #
 function read_elogs() {
-	elog_dir="/var/log/portage/elog"
+    elog_dir="/var/log/portage/elog"
 
-	# Check if the elog directory exists
-	if [[ ! -d "${elog_dir}" ]]; then
-		echo "Elog directory does not exist."
-		return
-	fi
+    # Check if the elog directory exists
+    if [[ ! -d "${elog_dir}" ]]; then
+        echo "Elog directory does not exist."
+        return
+    fi
 
-	current_time=$(date +%s)
-	timeframe=24
+    current_time=$(date +%s)
+    timeframe=24
 
-	# Find and print elogs that have been modified in the last 24 hours
-	find "${elog_dir}" -type f -mmin -$((60 * "${timeframe}")) -print0 |
-		while IFS= read -r -d '' file; do
-			modification_time=$(stat -c %Y "${file}")
-			if ((modification_time > (current_time - 60 * 60 * 24))); then
-				echo ""
-				echo ">>> Log filename: ${file}"
-				echo ">>> Log start <<<"
-				cat "${file}"
-				echo ">>> Log end <<<"
-				echo ""
-			fi
-		done
+    # Find and print elogs that have been modified in the last 24 hours
+    find "${elog_dir}" -type f -mmin -$((60 * "${timeframe}")) -print0 |
+        while IFS= read -r -d '' file; do
+            modification_time=$(stat -c %Y "${file}")
+            if ((modification_time > (current_time - 60 * 60 * 24))); then
+                echo ""
+                echo ">>> Log filename: ${file}"
+                echo ">>> Log start <<<"
+                cat "${file}"
+                echo ">>> Log end <<<"
+                echo ""
+            fi
+        done
 }
 
 function get_logs() {
-	read_elogs="${READ_ELOGS}"
-	if [[ "${read_elogs}" == 'y' ]]; then
-		echo "reading elogs"
-		read_elogs
-	else
-		echo "not reading elogs"
-	fi
+    read_elogs="${READ_ELOGS}"
+    if [[ "${read_elogs}" == 'y' ]]; then
+        echo "reading elogs"
+        read_elogs
+    else
+        echo "not reading elogs"
+    fi
 }
 
 # ----------------------- GET_NEWS ----------------------- #
 function get_news() {
-	read_news="${READ_NEWS}"
-	if [[ "${read_news}" == 'y' ]]; then
-		echo "Getting important news"
-		eselect news read new
-	else
-		echo "not reading news"
-	fi
+    read_news="${READ_NEWS}"
+    if [[ "${read_news}" == 'y' ]]; then
+        echo "Getting important news"
+        eselect news read new
+    else
+        echo "not reading news"
+    fi
 }
 
 # --------------------- RUN_PROGRAM ---------------------- #

--- a/gentoo_update/shell_runner.py
+++ b/gentoo_update/shell_runner.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import shlex
 import logging
 import subprocess
 from configparser import ConfigParser
@@ -160,7 +159,7 @@ class ShellRunner:
             *args (str): Arguments for the shell script.
                          They need to be handled by the script.
         """
-        command = shlex.split(f"{self.script_path} {' '.join(args)}")
+        command = [self.script_path] + list(args)
         with subprocess.Popen(
             command, stdout=subprocess.PIPE, stderr=subprocess.PIPE
         ) as script_stream:

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ classifiers =
 
 [options]
 python_requires = >=3.10
-packages = gentoo_update
+packages = find_namespace:
 include_package_data = True
 
 [options.entry_points]

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,11 +1,8 @@
 ### Testing
 
 #### Unit Test
-Initialize a virtual environment in the parent directory to run unit tests. 
-For example:
-```
-python -m venv venv
-source venv/bin/activate
+There is a simple unit test that can be run via:
+```bash
 python tests/test_updater.py
 ```
 
@@ -14,17 +11,19 @@ python tests/test_updater.py
 tarballs and runs a tests script (`tests/run_tests.sh`) on it.  
 
 Before running tests, make sure you have the directory to store logs:
+**NOTE** All commands below are run from `tests` directory
 ```bash
-mkdir ./tests/logs
+mkdir logs
 ```
 After a test is complete, the update log will be placed there which can be inspected.  
 Test Examples:
 ```bash
-# build a systemd base images, install gentoo-update with pip and run full update
-cd tests
-docker compose up gentoo1_source -d
+# build a systemd base image, install gentoo_update with pip and run full update
+docker compose up gentoo1_source
 
-# build an openrc desktop image, install gentoo-update from GURU repo and run security update
-cd tests
-docker compose up gentoo1 -d
+# build a systemd base image, install gentoo_update with pip and run full update with all available flags
+docker compose up gentoo2_source
+
+# build an openrc desktop image, install gentoo_update from GURU repo and run security update
+docker compose up gentoo1
 ```

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -3,34 +3,34 @@
 set -euo pipefail
 
 emerge_install() {
-	# Install from GURU repository
-	echo "app-admin/gentoo_update ~amd64" >>/etc/portage/package.accept_keywords/gentoo_update
-	emerge --quiet-build y app-admin/gentoo_update
+    # Install from GURU repository
+    echo "app-admin/gentoo_update ~amd64" >>/etc/portage/package.accept_keywords/gentoo_update
+    emerge --quiet-build y app-admin/gentoo_update
 }
 
 pip_install() {
-	# Install with pip
-	cd /root/gentoo_update_source && pip install . --break-system-packages
+    # Install with pip
+    cd /root/gentoo_update_source && pip install . --break-system-packages
 }
 
 sec_update() {
-	# Run the gentoo-update in secure mode
-	gentoo-update
+    # Run the gentoo-update in secure mode
+    gentoo-update
 }
 
 full_update() {
-	# Run the gentoo-update in full update mode
-	gentoo-update --update-mode full
+    # Run the gentoo-update in full update mode
+    gentoo-update --update-mode full
 }
 
 full_update_all_options() {
-	# Run the gentoo-update in full update mode and all options enabled
-	gentoo-update --update-mode full \
-		--config-update-mode merge \
-		--daemon-restart y \
-		--clean y \
-		--read-logs y \
-		--read-news y
+    # Run the gentoo-update in full update mode and all options enabled
+    gentoo-update --update-mode full \
+        --config-update-mode merge \
+        --daemon-restart y \
+        --clean y \
+        --read-logs y \
+        --read-news y
 }
 
 "$@"


### PR DESCRIPTION
Changelog:
* `--args` flag now takes one string as input instead of a list
* emerge command used for full update is now run via `eval`
* warning that was complaining about `updater.sh` not being a valid Python module is fixed
* Documentation updates
* Changed indentation in Bash scripts to == 4 spaces like in Python